### PR TITLE
Add app update method

### DIFF
--- a/tests/test_apps.py
+++ b/tests/test_apps.py
@@ -114,3 +114,26 @@ class AppsTestCase(unittest.TestCase):
         self.assertEqual(data["platform"], httpretty.last_request().parsed_body["platform"][0])
         self.assertEqual(data["pool"], httpretty.last_request().parsed_body["pool"][0])
         self.assertEqual(data["tag"], httpretty.last_request().parsed_body["tag"])
+
+    def test_update_app(self):
+        app_data = {}
+        url = "http://target/apps/appname"
+        httpretty.register_uri(
+            httpretty.PUT,
+            url,
+            body=json.dumps(app_data),
+            status=200
+        )
+
+        cl = client.Client("http://target", "abc123")
+        data = {
+            "pool": "mypool",
+            "plan": "myplan",
+            "router": "myrouter"
+        }
+        cl.apps.update("appname", **data)
+
+        self.assertEqual("bearer abc123", httpretty.last_request().headers["authorization"])
+        self.assertEqual(data["pool"], httpretty.last_request().parsed_body["pool"][0])
+        self.assertEqual(data["plan"], httpretty.last_request().parsed_body["plan"][0])
+        self.assertEqual(data["router"], httpretty.last_request().parsed_body["router"][0])

--- a/tsuruclient/apps.py
+++ b/tsuruclient/apps.py
@@ -33,3 +33,9 @@ class Manager(Base):
         Create an app.
         """
         return self.request("post", "/apps", stream=True, data=kwargs)
+
+    def update(self, appname, **kwargs):
+        """
+        Update an app.
+        """
+        return self.request("put", "/apps/{}".format(appname), stream=True, data=kwargs)


### PR DESCRIPTION
This addition is in order to facilitate a script that I wrote to bulk migrate app plans from the old tsuru 1.2 method of having a N*M matrix of plan-router to the simpler tsuru 1.3 scheme.